### PR TITLE
Manatoki: better way to parse the site

### DIFF
--- a/src/ManaToki/ManaToki.ts
+++ b/src/ManaToki/ManaToki.ts
@@ -189,7 +189,7 @@ export class ManaToki extends Source {
         }),
         section: createHomeSection({
           id: 'updates',
-          title: '최신',
+          title: '업데이트',
           view_more: true,
         }),
       },
@@ -231,15 +231,15 @@ export class ManaToki extends Source {
     let manga
     let mData = undefined
 
-    let target_url = (await this.getBaseURL())
+    let requestUrl = (await this.getBaseURL())
       .addPath("comic")
       .addPath(`p${page}`)
     
     if (homepageSectionId === 'updates')
-      target_url = target_url.addParam("sst", "as_update").addParam("sod", "desc")
+      requestUrl = requestUrl.addParam("sst", "as_update").addParam("sod", "desc")
 
     const request = createRequestObject({
-      url: target_url.build(),
+      url: requestUrl.build(),
       method: 'GET'
     })
 

--- a/src/ManaToki/ManaToki.ts
+++ b/src/ManaToki/ManaToki.ts
@@ -28,7 +28,6 @@ import {
   parseChapterDetails,
   parseChapters,
   parseHomeList,
-  parseHomeUpdates,
   parseMangaDetails,
   parseSearchResults,
   parseSearchTags,
@@ -182,15 +181,15 @@ export class ManaToki extends Source {
       {
         request: createRequestObject({
           url: (await this.getBaseURL())
-            .addPath("bbs")
-            .addPath("page.php")
-            .addParam("hid", "update")
+            .addPath("comic")
+            .addParam("sst", "as_update")
+            .addParam("sod", "desc")
             .build(),
           method: 'GET'
         }),
         section: createHomeSection({
           id: 'updates',
-          title: '최신화',
+          title: '최신',
           view_more: true,
         }),
       },
@@ -217,14 +216,7 @@ export class ManaToki extends Source {
       promises.push(
         this.requestManager.schedule(section.request, 3).then(response => {
           const $ = this.cheerio.load(response.data)
-          switch (section.section.id) {
-            case 'updates':
-              section.section.items = parseHomeUpdates($).manga
-              break
-            case 'list':
-              section.section.items = parseHomeList($).manga
-              break
-          }
+          section.section.items = parseHomeList($).manga
           sectionCallback(section.section)
         }),
       )
@@ -239,58 +231,28 @@ export class ManaToki extends Source {
     let manga
     let mData = undefined
 
-    switch (homepageSectionId) {
+    let target_url = (await this.getBaseURL())
+      .addPath("comic")
+      .addPath(`p${page}`)
+    
+    if (homepageSectionId === 'updates')
+      target_url = target_url.addParam("sst", "as_update").addParam("sod", "desc")
 
-      case 'updates': {
-        const request = createRequestObject({
-          url: (await this.getBaseURL())
-            .addPath("bbs")
-            .addPath("page.php")
-            .addParam("hid", "update")
-            .addParam("page", page)
-            .build(),
-          method: 'GET'
-        })
+    const request = createRequestObject({
+      url: target_url.build(),
+      method: 'GET'
+    })
 
-        const data = await this.requestManager.schedule(request, 3)
-        const $ = this.cheerio.load(data.data)
+    const data = await this.requestManager.schedule(request, 3)
+    const $ = this.cheerio.load(data.data)
 
-        const parsedData = parseHomeUpdates($, collectedIds)
-        manga = parsedData.manga
-        collectedIds = parsedData.collectedIds
+    const parsedData = parseHomeList($, collectedIds)
+    manga = parsedData.manga
+    collectedIds = parsedData.collectedIds
 
-        if (page <= 9)
-          mData = { page: (page + 1), collectedIds: collectedIds }
+    if (page <= 9)
+      mData = { page: (page + 1), collectedIds: collectedIds }
 
-        break
-      }
-      case 'list': {
-        const request = createRequestObject({
-          url: (await this.getBaseURL())
-            .addPath("comic")
-            .addPath(`p${page}`)
-            .build(),
-          method: 'GET'
-        })
-
-        const data = await this.requestManager.schedule(request, 3)
-        const $ = this.cheerio.load(data.data)
-
-        const parsedData = parseHomeList($, collectedIds)
-        manga = parsedData.manga
-        collectedIds = parsedData.collectedIds
-
-        if (page <= 9)
-          mData = { page: (page + 1), collectedIds: collectedIds }
-
-        break
-      }
-      default:
-        return createPagedResults({
-          results: [],
-          metadata: mData
-        })
-    }
 
     return createPagedResults({
       results: manga,

--- a/src/ManaToki/TokiParser.ts
+++ b/src/ManaToki/TokiParser.ts
@@ -26,6 +26,13 @@ const parseTime = (timeString: string): Date => {
   }
 };
 
+const parseChapterNumber = (chapterName: string): number => {
+  // Actual chapter number is on each chapter name.
+  // For example, "MangaName 1-2" is chapter 1-2, "MangaName 2.5화" is chapter 2.5, etc.
+  const ch = /([0-9]+)(?:[-.]([0-9]+))?(?:화)/.exec(chapterName) || [ '', '1', '0' ];
+  return Number(`${ch[1]}.${ch[2] ?? "0"}`)
+};
+
 export const parseSearchResults = ($: CheerioAPI, baseDomain: string): [MangaTile[], boolean] => {
   const results = $("#webtoon-list-all > li > div > div > .imgframe")
     .toArray()
@@ -124,7 +131,7 @@ export const parseChapters = ($: CheerioAPI, mangaId: string): Chapter[] => {
       })
       .text()
       .trim();
-    const chapNum = parseFloat($(".wr-num", chapter).text()) || 1;
+    const chapNum = parseChapterNumber(name); // parseFloat($(".wr-num", chapter).text()) || 1;
     const timeStr = $(".wr-date", chapter)
       .text()
       .trim();

--- a/src/ManaToki/TokiParser.ts
+++ b/src/ManaToki/TokiParser.ts
@@ -189,30 +189,6 @@ export const parseChapterDetails =
     });
   };
 
-export const parseHomeUpdates = ($: CheerioAPI, collectedIds?: string[]): { manga: MangaTile[], collectedIds: string[] } => {
-  const mangaTiles: MangaTile[] = []
-  if (!collectedIds) {
-    collectedIds = []
-  }
-
-  for (const item of $('.post-row', '.miso-post-webzine').toArray()) {
-    const id = $('a', $('.pull-right.post-info', item)).attr('href')?.split('/').pop() ?? ''
-    const title = $('a', $('.post-subject', item)).children().remove().end().text().trim()
-    const image = $('img', item).attr('src') ?? ''
-
-    if (!collectedIds.includes(id)) {
-      mangaTiles.push(createMangaTile({
-        id: id,
-        title: createIconText({ text: title }),
-        image: image
-      }))
-      collectedIds.push(id)
-    }
-  }
-
-  return { manga: mangaTiles, collectedIds: collectedIds }
-}
-
 export const parseHomeList = ($: CheerioAPI, collectedIds?: string[]): { manga: MangaTile[], collectedIds: string[] } => {
   const mangaTiles: MangaTile[] = []
   if (!collectedIds) {


### PR DESCRIPTION
2ddd6ef014adf35950443a7732383e40eb8b30df: The main menu's latest section is loaded by each chapter. so if site updates manga many times, it would be much duplicates in there. but there's a way to load by "manga" page directly. using hidden params (that i found on newtoki side).
e786f3b54e5aac5ec86ca66cd9fb9abb13ef6aca: The actual chapter number is only available on the each chapter's name. This will trying parse on name. mostly work. (As there's exception. but it's enough tho)

By the way, my eslint is somehow completely broken so i couldn't run the lint. sorry.